### PR TITLE
Fixing ListFun.addEle with position

### DIFF
--- a/Functional-Programming-Project/src/com/basicsstrong/functional/section14/ListFun.java
+++ b/Functional-Programming-Project/src/com/basicsstrong/functional/section14/ListFun.java
@@ -95,11 +95,11 @@ public abstract class ListFun<T> {
 	
 	//method to add element at specific position
 	public ListFun<T> addEle(int pos, T ele){
-		if(pos < 1 || pos > length())
+		if(pos < 0 || pos > length())
 			throw new IndexOutOfBoundsException();
-		if(pos == 1)
-			return this.tail().addEle(ele);
-		return new Const<T>(head(),addEle(pos-1,ele));
+		if(pos == 0)
+			return this.addEle(ele);
+		return new Const<T>(head(),tail().addEle(pos-1,ele));
 	}
 	
 	public void forEach(Consumer<? super T> action) {


### PR DESCRIPTION
First, the add is 1 indexed instead of 0 indexed like other structures would be (and as the remove is)

This test case for example:

```
ListFun<Integer> list1 = ListFun.list(3, 6, 9, 8);
list1.addEle(3, 25).forEach(System.out::println);
```

Will give: 3, 3, 25, 6, 9, 8 (the head is repeated twice). 

This will happen for any index greater than 2.

Also, this part:

```
if(pos == 0)
   return this.tail().addEle(ele);

```
Would replace the object at the given position with the new value instead of adding it and keeping the other elements of the list.